### PR TITLE
Remove blazor

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ At the same time, it preserves the flexibility of traditional untracked state ma
 - 🧪 **Synchronous Debug Mode** — Optional lockstep mode for testing, diagnostics, and `Task.WhenAll` pipelines.
 - 🧵 **DispatchTracker** — High-performance cancellation and deduplication logic via optimized concurrent tracking.
 
-### 🚀 **Blazor-Specific State Management with Zero Boilerplate and Zero Compromises**
+### 🚀 **State Management with Zero Boilerplate and Zero Compromises**
 
-- **Lazy State Access Model:** Inject `IPulse` directly into your Blazor component and call `StateOf<TState>(this)` to get scoped state access.  
+- **Lazy State Access Model:** Inject `IStatePulse` directly into your Blazor component and call `StateOf<TState>(()=>this,()=>InvokeAsync(StateHasChanged))` to get scoped state access.  
 - **Component-Scoped Event Listening:** Automatically registers event listeners only for that component, ensuring `StateHasChanged()` is called exclusively on components subscribed to state changes.  
 - **No Base Classes or Global Event Listeners:** Avoids global re-renders and boilerplate base class inheritance, giving you fine-grained control over component rendering and event subscription without forcing you into base classes.  
 - **Automatic Listener Disposal:** Event listeners are automatically tracked and disposed with the component lifecycle, preventing memory leaks and dangling references.  
-- **Transient `IPulse` Service:** Each component gets its own `IPulse` instance, isolating event subscriptions and making state updates scoped and efficient.
+- **Transient `IStatePulse` Service:** Each component gets its own `IStatePulse` instance, isolating event subscriptions and making state updates scoped and efficient.
 
 
 ## 📦 Installation & Setup

--- a/README.md
+++ b/README.md
@@ -40,42 +40,6 @@ services.AddStatePulseServices();
 services.ScanStatePulseAssemblies();
 ```
 
-
-
-## Use of StatePulse.Net.Blazor
-
-[![NuGet Version](https://img.shields.io/nuget/v/StatePulse.Net.Blazor)](https://www.nuget.org/packages/StatePulse.Net.Blazor)
-[![](https://img.shields.io/nuget/dt/StatePulse.Net.Blazor?label=Downloads)](https://www.nuget.org/packages/StatePulse.Net.Blazor)
-
-The water is already boiling guys... inject and enjoy!
-
-```
-Install-Package StatePulse.Net.Blazor
-
-dotnet add package StatePulse.Net.Blazor
-
-```
-
-```csharp
-using StatePulse.Net.Blazor;
-
-public partial class CounterView : ComponentBase
-{
-
-    // METHOD 1:
-    [Inject] public IPulse PulseState { get; set; } = default!; // Handles State Accessor
-    // This is for convienience so in your component you only use @state.Value instead of PulseState.StateOf<CounterState>(this).Value
-    private CounterState state => PulseState.StateOf<CounterState>(this);
-
-    // METHOD 2: 
-    // Inject direct state but injecting the state directly requires you to handle onchanged events but sub/unsub in lifecycle
-    // Or to create a basecomponent system similar to other state management systems.
-    [Inject] public IStateAccessor<CounterState> State { get; set; } = default!; 
-}
-```
-
-
-
 ## 🧭 How It Works
 
 
@@ -191,7 +155,7 @@ await dispatcher.Prepare<ProfileCardDefineAction>().With(p => p.TestData, name)
 
 
 ### Important Notes
-- Rule of thumb is always await dispatch calls avoiding to do so can cause inconsistency for safe dispatch modes..
+- Rule of thumb is always await dispatch calls, avoiding to do so can cause inconsistency for safe dispatch mode..
 - ISafeAction implementations are always dispatched safely, ignoring unsafe flags.
 - synchronous is an anti-pattern of statemanement use it sparingly; it is primarily for debugging or specific scenarios requiring full completion before continuation.
 
@@ -199,5 +163,25 @@ await dispatcher.Prepare<ProfileCardDefineAction>().With(p => p.TestData, name)
 
 ```csharp
 var stateAccessor = ServiceProvider.GetRequiredService<IStateAccessor<ProfileCardState>>();
-// See Above for Blazor Support
+```
+
+## Blazor Example Usage
+
+```csharp
+using StatePulse.Net;
+
+public partial class CounterView : ComponentBase
+{
+
+    // METHOD 1:
+    [Inject] public IStatePulse PulseState { get; set; } = default!; // Handles State Accessor
+
+    // This is for convienience so in your component you only use @state.Value instead of PulseState.StateOf<CounterState>(this).Value
+    private CounterState state => PulseState.StateOf<CounterState>(()=>this, ()=>InvokeAsync(StateHadChanged));
+
+    // METHOD 2: 
+    // Inject direct state but injecting the state directly requires you to handle onchanged events but sub/unsub in lifecycle
+    // Or to create a basecomponent system similar to other state management systems.
+    [Inject] public IStateAccessor<CounterState> State { get; set; } = default!; 
+}
 ```

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,9 +1,8 @@
-## StatePulse.Net v0.9.3
+## StatePulse.Net v0.9.21
 - Implement the Blazor Package and removed dependencies to Blazor ComponentBase which is no longer required... 
-- Any objects within .NET can now use IPulse and benefit from state management without extra implementations.
-- Added InitializeAsync where you can called in oninitialize blazor to define InvokeAsync(()=>StateHasChanged).
-- Added a Lazy Alternative where you skip the boilerplate and call StateOf<>() where you can also define the InvokeAsync.
-- The InitializeAsync and StateOf<>() are usable by any object to start listening and stop listening when caller dies.
+- Any objects within .NET can now use IStatePulse and benefit from state management without extra implementations.
+- Renamed IPulse to IStatePulse
+- using IStatePulse.StateOf<>(()=>this, () => InvokeAsync(StateHasChanged));
 
 
 ## Blazor Packages v0.9.2

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,13 @@
+## StatePulse.Net v0.9.3
+- Implement the Blazor Package and removed dependencies to Blazor ComponentBase which is no longer required... 
+- Any objects within .NET can now use IPulse and benefit from state management without extra implementations.
+- Added InitializeAsync where you can called in oninitialize blazor to define InvokeAsync(()=>StateHasChanged).
+- Added a Lazy Alternative where you skip the boilerplate and call StateOf<>() where you can also define the InvokeAsync.
+- The InitializeAsync and StateOf<>() are usable by any object to start listening and stop listening when caller dies.
+
+
+## Blazor Packages v0.9.2
+- Deprecated now part of StatePulse regular since we have removed the dependencies to blazor component.
+... that was quick!
+
+

--- a/src/StatePulse.NET.sln
+++ b/src/StatePulse.NET.sln
@@ -6,6 +6,7 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		..\RELEASES.md = ..\RELEASES.md
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StatePulse.NET.Tests", "..\tests\StatPulse.NET.Tests\StatePulse.NET.Tests.csproj", "{07ED17B2-BD3A-94F4-FA85-43E768FAF9F0}"
@@ -13,8 +14,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StatePulse.NET", "StatePulse.NET\StatePulse.NET.csproj", "{001E330A-2F3E-D401-1119-2C5AEC9243AA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StatePulse.Net.Tests.App", "..\tests\StatePulse.Net.Tests.App\StatePulse.Net.Tests.App.csproj", "{2C1CC5ED-698A-41D9-9436-629115326499}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StatePulse.Net.Blazor", "StatePulse.Net.Blazor\StatePulse.Net.Blazor.csproj", "{DF95156F-18E4-4EA8-80B0-13713CF0A9D3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -36,10 +35,6 @@ Global
 		{2C1CC5ED-698A-41D9-9436-629115326499}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2C1CC5ED-698A-41D9-9436-629115326499}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2C1CC5ED-698A-41D9-9436-629115326499}.Release|Any CPU.Deploy.0 = Release|Any CPU
-		{DF95156F-18E4-4EA8-80B0-13713CF0A9D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{DF95156F-18E4-4EA8-80B0-13713CF0A9D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DF95156F-18E4-4EA8-80B0-13713CF0A9D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{DF95156F-18E4-4EA8-80B0-13713CF0A9D3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/StatePulse.NET/Engine/Implementations/PulseGlobalTracker.cs
+++ b/src/StatePulse.NET/Engine/Implementations/PulseGlobalTracker.cs
@@ -1,11 +1,10 @@
-﻿
-namespace StatePulse.Net.Blazor.Engine.Implementation;
+﻿namespace StatePulse.Net.Engine.Implementations;
 internal class PulseGlobalTracker : IPulseGlobalTracker
 {
     private readonly object _lock = new();
     public int ActivePulsars { get => _registry.Count; }
-    private readonly List<IPulse> _registry = new();
-    private IReadOnlyList<IPulse> _readRegistry
+    private readonly List<IStatePulse> _registry = new();
+    private IReadOnlyList<IStatePulse> _readRegistry
     {
         get
         {
@@ -21,12 +20,12 @@ internal class PulseGlobalTracker : IPulseGlobalTracker
     {
         _timer = new Timer(GarbageCollecting, null, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10));
     }
-    public void Register(IPulse pulsar)
+    public void Register(IStatePulse pulsar)
     {
         lock (_lock)
             _registry.Add(pulsar);
     }
-    public void UnRegister(IPulse pulsar)
+    public void UnRegister(IStatePulse pulsar)
     {
         lock (_lock)
             _registry.Remove(pulsar);

--- a/src/StatePulse.NET/Engine/Implementations/PulseLazyStateBlazorServer.cs
+++ b/src/StatePulse.NET/Engine/Implementations/PulseLazyStateBlazorServer.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Concurrent;
+
+namespace StatePulse.Net.Engine;
+internal sealed class PulseLazyStateBlazorServer : PulseLazyStateBase
+{
+    private readonly ConcurrentDictionary<Type, IStateAccessor<object>> _stash = new();
+    public PulseLazyStateBlazorServer(IServiceProvider services) : base(services)
+    {
+    }
+    protected override IDictionary<Type, IStateAccessor<object>> GetState() => _stash;
+}

--- a/src/StatePulse.NET/Engine/Implementations/PulseLazyStateWebAssembly.cs
+++ b/src/StatePulse.NET/Engine/Implementations/PulseLazyStateWebAssembly.cs
@@ -1,0 +1,13 @@
+﻿namespace StatePulse.Net.Engine;
+using System;
+
+internal sealed class PulseLazyStateWebAssembly : PulseLazyStateBase
+{
+    private readonly Dictionary<Type, IStateAccessor<object>> _stash = new();
+
+    public PulseLazyStateWebAssembly(IServiceProvider services) : base(services)
+    {
+    }
+
+    protected override IDictionary<Type, IStateAccessor<object>> GetState() => _stash;
+}

--- a/src/StatePulse.NET/IPulseGlobalTracker.cs
+++ b/src/StatePulse.NET/IPulseGlobalTracker.cs
@@ -1,0 +1,8 @@
+﻿namespace StatePulse.Net;
+public interface IPulseGlobalTracker
+{
+    public int ActivePulsars { get; }
+    public void Register(IStatePulse pulsar);
+    public void UnRegister(IStatePulse pulsar);
+    public event EventHandler? onAfterCleanUp;
+}

--- a/src/StatePulse.NET/IStatePulse.cs
+++ b/src/StatePulse.NET/IStatePulse.cs
@@ -1,0 +1,11 @@
+﻿namespace StatePulse.Net;
+public interface IStatePulse : IDisposable
+{
+    TState StateOf<TState>(object instance) where TState : IStateFeature;
+
+    TState StateOf<TState>(object instance, Func<Task> onStateChanged) where TState : IStateFeature;
+    Task InitializeListennerAsync(object instance, Func<Task> onStateChanged);
+    bool IsReferenceAlive();
+    void SelfDisposeCheck();
+
+}

--- a/src/StatePulse.NET/IStatePulse.cs
+++ b/src/StatePulse.NET/IStatePulse.cs
@@ -1,10 +1,7 @@
 ﻿namespace StatePulse.Net;
 public interface IStatePulse : IDisposable
 {
-    TState StateOf<TState>(object instance) where TState : IStateFeature;
-
-    TState StateOf<TState>(object instance, Func<Task> onStateChanged) where TState : IStateFeature;
-    Task InitializeListennerAsync(object instance, Func<Task> onStateChanged);
+    TState StateOf<TState>(Func<object> getInstance, Func<Task> onStateChanged) where TState : IStateFeature;
     bool IsReferenceAlive();
     void SelfDisposeCheck();
 

--- a/src/StatePulse.NET/ServiceRegisterExt.cs
+++ b/src/StatePulse.NET/ServiceRegisterExt.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using StatePulse.Net.Configuration;
+using StatePulse.Net.Engine;
 using StatePulse.Net.Engine.Implementations;
 
 namespace StatePulse.Net;
@@ -17,6 +18,14 @@ public static class ServiceRegisterExt
         services.AddTransient<IDispatcher, Dispatcher>();
         services.AddTransient<IDispatchFactory, DispatchFactory>();
         configure(_configureOptions);
+
+        if (_configureOptions.ServiceLifetime == LifetimeEnum.Scoped)
+            services.AddScoped<IPulseGlobalTracker, PulseGlobalTracker>();
+        else
+            services.AddSingleton<IPulseGlobalTracker, PulseGlobalTracker>();
+
+        services.AddTransient<IStatePulse, PulseLazyStateWebAssembly>();
+        services.AddTransient<IStatePulse, PulseLazyStateBlazorServer>();
         services.ScanStatePulseAssemblies(_configureOptions.ScanAssemblies);
         return services;
     }

--- a/src/StatePulse.NET/StatePulse.NET.csproj
+++ b/src/StatePulse.NET/StatePulse.NET.csproj
@@ -42,4 +42,13 @@
 		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.6" />
 	</ItemGroup>
+
+    <Target Name="CopyNuPkg" AfterTargets="Pack" Condition="'$(Configuration)' == 'Release'">
+	    <MakeDir Directories="..\..\..\..\nupkgs" />
+	    <ItemGroup>
+		    <PackageFiles Include="$(PackageOutputPath)$(PackageId).$(PackageVersion).nupkg" />
+	    </ItemGroup>
+	    <Copy SourceFiles="@(PackageFiles)" DestinationFolder="..\..\..\..\nupkgs" OverwriteReadOnlyFiles="true" SkipUnchangedFiles="false" />
+    </Target>
+	
 </Project>

--- a/src/StatePulse.NET/StatePulse.NET.csproj
+++ b/src/StatePulse.NET/StatePulse.NET.csproj
@@ -14,7 +14,7 @@
 	  <Product>StatePulse.NET</Product>
 	  <Company />
 	  <Authors>Maksim Shimshon</Authors>
-	  <Version>0.9.2</Version>
+	  <Version>0.9.3</Version>
 	  <PackageLicenseFile>LICENSE</PackageLicenseFile>
 	  <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 	  <Description>StatePulse.NET enables fast, consistent state/action dispatch with optional tracking and anti-duplicate flow control. It supports ordered chaining when needed, while maintaining high-performance fire-and-forget behavior for general use cases.</Description>

--- a/src/StatePulse.Net.Blazor/Engine/IPulseGlobalTracker.cs
+++ b/src/StatePulse.Net.Blazor/Engine/IPulseGlobalTracker.cs
@@ -1,8 +1,0 @@
-﻿namespace StatePulse.Net.Blazor.Engine;
-public interface IPulseGlobalTracker
-{
-    public int ActivePulsars { get; }
-    public void Register(IPulse pulsar);
-    public void UnRegister(IPulse pulsar);
-    public event EventHandler? onAfterCleanUp;
-}

--- a/src/StatePulse.Net.Blazor/IPulse.cs
+++ b/src/StatePulse.Net.Blazor/IPulse.cs
@@ -1,8 +1,0 @@
-﻿namespace StatePulse.Net.Blazor;
-public interface IPulse : IDisposable
-{
-    TState StateOf<TState>(object instance) where TState : IStateFeature;
-    bool IsReferenceAlive();
-    void SelfDisposeCheck();
-
-}

--- a/src/StatePulse.Net.Blazor/ServiceRegisterExt.cs
+++ b/src/StatePulse.Net.Blazor/ServiceRegisterExt.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using StatePulse.Net.Blazor.Engine;
 using StatePulse.Net.Blazor.Engine.Implementation;
 
 namespace StatePulse.Net.Blazor;
@@ -10,11 +9,11 @@ public static class ServiceRegisterExt
         services.AddScoped<IPulseGlobalTracker, PulseGlobalTracker>();
         if (wasm)
         {
-            services.AddTransient<IPulse, PulseLazyStateWebAssembly>();
+            services.AddTransient<IStatePulse, PulseLazyStateWebAssembly>();
         }
         else
         {
-            services.AddTransient<IPulse, PulseLazyStateBlazorServer>();
+            services.AddTransient<IStatePulse, PulseLazyStateBlazorServer>();
         }
         return services;
     }

--- a/src/StatePulse.Net.Blazor/StatePulse.Net.Blazor.csproj
+++ b/src/StatePulse.Net.Blazor/StatePulse.Net.Blazor.csproj
@@ -15,7 +15,7 @@
 		<Product>StatePulse.Net.Blazor</Product>
 		<Company />
 		<Authors>Maksim Shimshon</Authors>
-		<Version>0.9.2</Version>
+		<Version>0.9.3</Version>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<Description>StatePulse.NET enables fast, consistent state/action dispatch with optional tracking and anti-duplicate flow control. It supports ordered chaining when needed, while maintaining high-performance fire-and-forget behavior for general use cases.</Description>

--- a/tests/StatePulse.Net.Tests.App/Components/CounterView.razor.cs
+++ b/tests/StatePulse.Net.Tests.App/Components/CounterView.razor.cs
@@ -5,5 +5,5 @@ namespace StatePulse.Net.Tests.App.Components;
 public partial class CounterView : ComponentBase
 {
     [Inject] IStatePulse PulseState { get; set; } = default!;
-    private CounterState State => PulseState.StateOf<CounterState>(this, () => InvokeAsync(StateHasChanged));
+    private CounterState State => PulseState.StateOf<CounterState>(() => this, () => InvokeAsync(StateHasChanged));
 }

--- a/tests/StatePulse.Net.Tests.App/Components/CounterView.razor.cs
+++ b/tests/StatePulse.Net.Tests.App/Components/CounterView.razor.cs
@@ -1,10 +1,9 @@
 ﻿using Microsoft.AspNetCore.Components;
-using StatePulse.Net.Blazor;
 using StatePulse.Net.Tests.App.Pulsars.Counter.Stores;
 
 namespace StatePulse.Net.Tests.App.Components;
 public partial class CounterView : ComponentBase
 {
-    [Inject] IPulse PulseState { get; set; } = default!;
-    private CounterState State => PulseState.StateOf<CounterState>(this);
+    [Inject] IStatePulse PulseState { get; set; } = default!;
+    private CounterState State => PulseState.StateOf<CounterState>(this, () => InvokeAsync(StateHasChanged));
 }

--- a/tests/StatePulse.Net.Tests.App/Components/Layout/NavMenu.razor.cs
+++ b/tests/StatePulse.Net.Tests.App/Components/Layout/NavMenu.razor.cs
@@ -5,6 +5,6 @@ namespace StatePulse.Net.Tests.App.Components.Layout;
 public partial class NavMenu
 {
     [Inject] IStatePulse PulseState { get; set; } = default!;
-    private CounterState State => PulseState.StateOf<CounterState>(this, () => InvokeAsync(StateHasChanged));
+    private CounterState State => PulseState.StateOf<CounterState>(() => this, () => InvokeAsync(StateHasChanged));
 
 }

--- a/tests/StatePulse.Net.Tests.App/Components/Layout/NavMenu.razor.cs
+++ b/tests/StatePulse.Net.Tests.App/Components/Layout/NavMenu.razor.cs
@@ -1,11 +1,10 @@
 ﻿using Microsoft.AspNetCore.Components;
-using StatePulse.Net.Blazor;
 using StatePulse.Net.Tests.App.Pulsars.Counter.Stores;
 
 namespace StatePulse.Net.Tests.App.Components.Layout;
 public partial class NavMenu
 {
-    [Inject] IPulse PulseState { get; set; } = default!;
-    private CounterState State => PulseState.StateOf<CounterState>(this);
+    [Inject] IStatePulse PulseState { get; set; } = default!;
+    private CounterState State => PulseState.StateOf<CounterState>(this, () => InvokeAsync(StateHasChanged));
 
 }

--- a/tests/StatePulse.Net.Tests.App/Components/Pages/Home.razor.cs
+++ b/tests/StatePulse.Net.Tests.App/Components/Pages/Home.razor.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.AspNetCore.Components;
-using StatePulse.Net.Blazor.Engine;
 using StatePulse.Net.Tests.App.Pulsars.Counter.Action;
 
 namespace StatePulse.Net.Tests.App.Components.Pages;

--- a/tests/StatePulse.Net.Tests.App/MauiProgram.cs
+++ b/tests/StatePulse.Net.Tests.App/MauiProgram.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
-using StatePulse.Net.Blazor;
-namespace StatePulse.Net.Tests.App;
+﻿namespace StatePulse.Net.Tests.App;
 public static class MauiProgram
 {
     public static MauiApp CreateMauiApp()
@@ -16,7 +14,6 @@ public static class MauiProgram
         {
             o.ScanAssemblies = new Type[] { typeof(MauiProgram) };
         });
-        builder.Services.AddStatePulseBlazor();
         builder.Services.AddMauiBlazorWebView();
 
 #if DEBUG

--- a/tests/StatePulse.Net.Tests.App/Pulsars/Counter/Reducers/CounterIncreaseReducer.cs
+++ b/tests/StatePulse.Net.Tests.App/Pulsars/Counter/Reducers/CounterIncreaseReducer.cs
@@ -5,7 +5,5 @@ namespace StatePulse.Net.Tests.App.Pulsars.Counter.Reducers;
 internal class CounterIncreaseReducer : IReducer<CounterState, CounterIncreaseAction>
 {
     public Task<CounterState> ReduceAsync(CounterState state, CounterIncreaseAction action)
-        => ReducerExt.ReducerResult(state)
-            .With(p => p.Count, state.Count + 1)
-            .ToTask();
+        => Task.FromResult(state with { Count = state.Count + 1 });
 }

--- a/tests/StatePulse.Net.Tests.App/StatePulse.Net.Tests.App.csproj
+++ b/tests/StatePulse.Net.Tests.App/StatePulse.Net.Tests.App.csproj
@@ -66,7 +66,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\src\StatePulse.Net.Blazor\StatePulse.Net.Blazor.csproj" />
       <ProjectReference Include="..\..\src\StatePulse.NET\StatePulse.NET.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
**Breaking Changes**

- StatePulse.Net.Blazor is deprecated

I deprecated the blazor package because i successfully remove dependencies to component references and allow the IPulse to work with any .NET applications.

- `IPulse` renamed to `IStatePulse`
- `StateOf<T>(this);` -> changed to -> `StateOf<T>(()=>this, ()=>InvokeAsync(StatehasChanged));` 

Will be better and easier to use across Components and View Model on Clean Architecture Front-End.